### PR TITLE
Add new service …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /.vs/APIwithTest/v17
 /.vs/APIwithTest/FileContentIndex
 /.vs
+/APIwithTest.API/APIwithTest.Test/bin/Release/net6.0

--- a/APIwithTest.API/APIwithTest.API/Controllers/CatalogController.cs
+++ b/APIwithTest.API/APIwithTest.API/Controllers/CatalogController.cs
@@ -1,0 +1,54 @@
+﻿using APIwithTest.Services.Interfaces;
+using APIwithTest.Services.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace APIwithTest.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class CatalogController : ControllerBase
+    {
+        private readonly ICatalogService catalogService;
+        public CatalogController(ICatalogService catalogService)
+        {
+            this.catalogService = catalogService;
+        }
+
+        [HttpGet()]
+        public IActionResult GetAll()
+        {
+            return Ok(catalogService.GetAll());
+        }
+
+        [HttpGet("{id}")]
+        public IActionResult GetById(int id)
+        {
+            return Ok(catalogService.GetById(new Catalog { Id = id }));
+        }
+
+        [HttpGet("ByName/{name}")]
+        public IActionResult GetByName(string name)
+        {
+            return Ok(catalogService.GetByName(new Catalog { Name = name }));
+        }
+
+        [HttpPost]
+        public IActionResult Post([FromBody] Catalog item)
+        {
+            var result = catalogService.SaveNew(item);
+            return Ok(result);
+        }
+
+        [HttpPut("{id}")]
+        public IActionResult Put([FromQuery]int id, [FromBody] Catalog item)
+        {
+            if (id == item.Id)
+            {
+                var result = catalogService.Update(item);
+                return Ok(result);
+            }
+            return BadRequest();
+        }
+    }
+}

--- a/APIwithTest.API/APIwithTest.API/Controllers/TypeCatalogController.cs
+++ b/APIwithTest.API/APIwithTest.API/Controllers/TypeCatalogController.cs
@@ -15,19 +15,19 @@ namespace APIwithTest.API.Controllers
             this.typeCatalogService = typeCatalogService;
         }
 
-        [HttpGet("GetAll")]
+        [HttpGet()]
         public IActionResult GetAll()
         {
             return Ok(typeCatalogService.GetAll());
         }
 
-        [HttpGet("GetById")]
+        [HttpGet("{id}")]
         public IActionResult GetById(int id)
         {
             return Ok(typeCatalogService.GetById(new TypeCatalog { Id = id }));
         }
 
-        [HttpGet("GetByName")]
+        [HttpGet("ByName/{name}")]
         public IActionResult GetByName(string name)
         {
             return Ok(typeCatalogService.GetByName(new TypeCatalog { Name = name }));

--- a/APIwithTest.API/APIwithTest.API/Program.cs
+++ b/APIwithTest.API/APIwithTest.API/Program.cs
@@ -8,6 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add scoped services to the container. This kind services lives during each instance.
 builder.Services.AddScoped<ITypeCatalogService, TypeCatalogService>();
+builder.Services.AddScoped<ICatalogService, CatalogService>();
 
 // Add transient services to the container. This kind of services lives during each request.
 

--- a/APIwithTest.API/APIwithTest.Services/Interfaces/IBaseService.cs
+++ b/APIwithTest.API/APIwithTest.Services/Interfaces/IBaseService.cs
@@ -1,0 +1,15 @@
+﻿using APIwithTest.Services.Models;
+
+namespace APIwithTest.Services.Interfaces
+{
+    public interface IBaseService<T> where T : BaseClass
+    {
+        IEnumerable<T> GetAll();
+
+        T GetById(T item);
+
+        IEnumerable<T> SaveNew(T item);
+
+        IEnumerable<T> Delete(T item);
+    }
+}

--- a/APIwithTest.API/APIwithTest.Services/Interfaces/ICatalogService.cs
+++ b/APIwithTest.API/APIwithTest.Services/Interfaces/ICatalogService.cs
@@ -1,0 +1,15 @@
+﻿using APIwithTest.Services.Models;
+
+namespace APIwithTest.Services.Interfaces
+{
+    public interface ICatalogService : IBaseService<Catalog>
+    {
+        IEnumerable<Catalog> GetByName(Catalog item);
+
+        IEnumerable<Catalog> Update(Catalog item);
+
+        IEnumerable<Catalog> UpdateName(Catalog item);
+
+        IEnumerable<Catalog> UpdateTypeCatalogId(Catalog item);
+    }
+}

--- a/APIwithTest.API/APIwithTest.Services/Interfaces/ITypeCatalogService.cs
+++ b/APIwithTest.API/APIwithTest.Services/Interfaces/ITypeCatalogService.cs
@@ -2,22 +2,14 @@
 
 namespace APIwithTest.Services.Interfaces
 {
-    public interface ITypeCatalogService
+    public interface ITypeCatalogService: IBaseService<TypeCatalog>
     {
-        IEnumerable<TypeCatalog> GetAll();
-
         IEnumerable<TypeCatalog> GetByName(TypeCatalog catalog);
-
-        TypeCatalog GetById(TypeCatalog catalog);
-
-        IEnumerable<TypeCatalog> SaveNew(TypeCatalog catalog);
 
         IEnumerable<TypeCatalog> Update(TypeCatalog catalog);
 
         IEnumerable<TypeCatalog> UpdateName(TypeCatalog catalog);
 
         IEnumerable<TypeCatalog> UpdateDescription(TypeCatalog catalog);
-
-        IEnumerable<TypeCatalog> Delete(TypeCatalog catalog);
     }
 }

--- a/APIwithTest.API/APIwithTest.Services/Models/Catalog.cs
+++ b/APIwithTest.API/APIwithTest.Services/Models/Catalog.cs
@@ -1,0 +1,9 @@
+﻿namespace APIwithTest.Services.Models
+{
+    public class Catalog : BaseClass
+    {
+        public string Name { get; set; }
+        public int TypeCatalogId { get; set; }
+        public string? TypeCatalog { get; set; }
+    }
+}

--- a/APIwithTest.API/APIwithTest.Services/Services/BaseService.cs
+++ b/APIwithTest.API/APIwithTest.Services/Services/BaseService.cs
@@ -1,0 +1,52 @@
+﻿using APIwithTest.Services.Interfaces;
+using APIwithTest.Services.Models;
+using System.Data;
+
+namespace APIwithTest.Services.Services
+{
+    public class BaseService<T> 
+        where T: BaseClass
+    {
+        public IEnumerable<T> collection { get; set; }
+
+        public IEnumerable<T> GetAll()
+        {
+            return collection.AsQueryable();
+        }
+
+        public T GetById(T item)
+        {
+            T? result = collection.FirstOrDefault(c => c.Id == item.Id);
+            if (result != null)
+            {
+                return result;
+            }
+            throw new DataException($"{typeof(T).Name} not found.");
+        }
+
+        public IEnumerable<T> SaveNew(T item)
+        {
+            if (item != null)
+            {
+                if (!collection.Any(c => c.Id == item.Id))
+                {
+                    ((List<T>)collection).Add(item);
+                    return collection.AsQueryable();
+                }
+                throw new DataException($"{typeof(T).Name} already exists.");
+            }
+            throw new ArgumentNullException("item", $"The {typeof(T).Name} data must not be mull.");
+        }
+
+        public IEnumerable<T> Delete(T item)
+        {
+            T? toDelete = collection.FirstOrDefault(t => t.Id == item.Id);
+            if (toDelete != null)
+            {
+                ((List<T>)collection).Remove(toDelete);
+                return collection.AsQueryable();
+            }
+            throw new InvalidDataException("Item not found.");
+        }
+    }
+}

--- a/APIwithTest.API/APIwithTest.Services/Services/CatalogService.cs
+++ b/APIwithTest.API/APIwithTest.Services/Services/CatalogService.cs
@@ -1,0 +1,75 @@
+﻿using APIwithTest.Services.Interfaces;
+using APIwithTest.Services.Models;
+using System.Data;
+
+namespace APIwithTest.Services.Services
+{
+    public class CatalogService : BaseService<Catalog>, ICatalogService
+    {
+        private IEnumerable<Catalog> _catalogData = new List<Catalog>
+        {
+            new Catalog{ Id = 1, Name = "A", TypeCatalogId = 1},
+            new Catalog{ Id = 2, Name = "B", TypeCatalogId = 1},
+            new Catalog{ Id = 3, Name = "AB", TypeCatalogId = 1},
+            new Catalog{ Id = 4, Name = "O", TypeCatalogId = 1},
+            new Catalog{ Id = 5, Name = "Celular", TypeCatalogId = 2},
+            new Catalog{ Id = 6, Name = "Fijo", TypeCatalogId = 2},
+        };
+
+        public CatalogService():base()
+        {
+            collection = _catalogData;
+        }
+
+        public IEnumerable<Catalog> GetByName(Catalog catalog)
+        {
+            return collection.Where(c => c.Name.ToUpper().Contains(catalog.Name.ToUpper())).AsQueryable();
+        }
+
+        public IEnumerable<Catalog> Update(Catalog catalog)
+        {
+            if (catalog != null)
+            {
+                Catalog? toUpdate = collection.FirstOrDefault(c => c.Id == catalog.Id);
+                if (toUpdate != null)
+                {
+                    toUpdate.Name = catalog.Name;
+                    toUpdate.TypeCatalogId = catalog.TypeCatalogId;
+                    return collection.AsQueryable();
+                }
+                throw new DataException("Item not found.");
+            }
+            throw new ArgumentNullException("catalog", "The item data must not be mull.");
+        }
+
+        public IEnumerable<Catalog> UpdateTypeCatalogId(Catalog catalog)
+        {
+            if (catalog != null)
+            {
+                Catalog? toUpdate = collection.FirstOrDefault(c => c.Id == catalog.Id);
+                if (toUpdate != null)
+                {
+                    toUpdate.TypeCatalogId = catalog.TypeCatalogId;
+                    return collection.AsQueryable();
+                }
+                throw new DataException("Item not found.");
+            }
+            throw new ArgumentNullException("catalog", "The item data must not be mull.");
+        }
+
+        public IEnumerable<Catalog> UpdateName(Catalog catalog)
+        {
+            if (catalog != null)
+            {
+                Catalog? toUpdate = collection.FirstOrDefault(c => c.Id == catalog.Id);
+                if (toUpdate != null)
+                {
+                    toUpdate.Name = catalog.Name;
+                    return collection.AsQueryable();
+                }
+                throw new DataException("Item not found.");
+            }
+            throw new ArgumentNullException("catalog", "The item data must not be mull.");
+        }
+    }
+}

--- a/APIwithTest.API/APIwithTest.Services/Services/TypeCatalogService.cs
+++ b/APIwithTest.API/APIwithTest.Services/Services/TypeCatalogService.cs
@@ -1,65 +1,38 @@
 ﻿using APIwithTest.Services.Interfaces;
 using APIwithTest.Services.Models;
-using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace APIwithTest.Services.Services
 {
-    public class TypeCatalogService : ITypeCatalogService
+    public class TypeCatalogService : BaseService<TypeCatalog>, ITypeCatalogService
     {
         private List<TypeCatalog> _catalogData = new List<TypeCatalog>
         {
-            new TypeCatalog{ Id = 1, Name = "Tipo de sangre", Description = "Tipos de sangre existentes"}
+            new TypeCatalog{ Id = 1, Name = "Tipo de sangre", Description = "Tipos de sangre existentes"},
+            new TypeCatalog{ Id = 2, Name = "Tipo de Teléfono", Description = "Tipos de teléfono de contacto"},
+            new TypeCatalog{ Id = 3, Name = "Parentesco", Description = "Tipos de parentesco"}
         };
 
-        public IEnumerable<TypeCatalog> GetAll()
+        public TypeCatalogService():base()
         {
-            return _catalogData.AsQueryable();
-        }
-
-        public TypeCatalog GetById(TypeCatalog catalog)
-        {
-            TypeCatalog? result = _catalogData.FirstOrDefault(c => c.Id == catalog.Id);
-            if (result != null)
-            {
-                return result;
-            }
-            throw new DataException("Catalog not found.");
+            collection = _catalogData;
         }
 
         public IEnumerable<TypeCatalog> GetByName(TypeCatalog catalog)
         {
-            return _catalogData.Where(c => c.Name.ToUpper().Contains(catalog.Name.ToUpper())).AsQueryable();
-        }
-
-        public IEnumerable<TypeCatalog> SaveNew(TypeCatalog catalog)
-        {
-            if (catalog != null)
-            {
-                if (!_catalogData.Any(c => c.Id == catalog.Id))
-                {
-                    _catalogData.Add(catalog);
-                    return _catalogData.AsQueryable();
-                }
-                throw new DataException("Catalog already exists.");
-            }
-            throw new ArgumentNullException("catalog", "The catalog type data must not be mull.");
+            return collection.Where(c => c.Name.ToUpper().Contains(catalog.Name.ToUpper())).AsQueryable();
         }
 
         public IEnumerable<TypeCatalog> Update(TypeCatalog catalog)
         {
             if (catalog != null)
             {
-                TypeCatalog? toUpdate = _catalogData.FirstOrDefault(c => c.Id == catalog.Id);
+                TypeCatalog? toUpdate = collection.FirstOrDefault(c => c.Id == catalog.Id);
                 if (toUpdate != null)
                 {
                     toUpdate.Name = catalog.Name;
                     toUpdate.Description = catalog.Description;
-                    return _catalogData.AsQueryable();
+                    return collection.AsQueryable();
                 }
                 throw new DataException("catalog not found.");
             }
@@ -70,11 +43,11 @@ namespace APIwithTest.Services.Services
         {
             if (catalog != null)
             {
-                TypeCatalog? toUpdate = _catalogData.FirstOrDefault(c => c.Id == catalog.Id);
+                TypeCatalog? toUpdate = collection.FirstOrDefault(c => c.Id == catalog.Id);
                 if (toUpdate != null)
                 {
                     toUpdate.Description = catalog.Description;
-                    return _catalogData.AsQueryable();
+                    return collection.AsQueryable();
                 }
                 throw new DataException("catalog not found.");
             }
@@ -85,26 +58,15 @@ namespace APIwithTest.Services.Services
         {
             if (catalog != null)
             {
-                TypeCatalog? toUpdate = _catalogData.FirstOrDefault(c => c.Id == catalog.Id);
+                TypeCatalog? toUpdate = collection.FirstOrDefault(c => c.Id == catalog.Id);
                 if (toUpdate != null)
                 {
                     toUpdate.Name = catalog.Name;
-                    return _catalogData.AsQueryable();
+                    return collection.AsQueryable();
                 }
                 throw new DataException("catalog not found.");
             }
             throw new ArgumentNullException("catalog", "The catalog type data must not be mull.");
-        }
-
-        public IEnumerable<TypeCatalog> Delete(TypeCatalog catalog)
-        {
-            TypeCatalog? toDelete = _catalogData.FirstOrDefault(t => t.Id == catalog.Id);
-            if (toDelete != null)
-            {
-                _catalogData.Remove(toDelete);
-                return _catalogData.AsQueryable();
-            }
-            throw new InvalidDataException("Catalog not found.");
         }
     }
 }

--- a/APIwithTest.API/APIwithTest.Test/CatalogTest.cs
+++ b/APIwithTest.API/APIwithTest.Test/CatalogTest.cs
@@ -4,14 +4,14 @@ using APIwithTest.Services.Services;
 
 namespace APIwithTest.Test
 {
-    public class TypeCatalogTest
+    public class CatalogTest
     {
-        private ITypeCatalogService service;
+        private ICatalogService service;
 
         [SetUp]
         public void Setup()
         {
-            service = new TypeCatalogService();
+            service = new CatalogService();
         }
 
         [Test]
@@ -20,46 +20,46 @@ namespace APIwithTest.Test
             var result = service.GetAll();
             Assert.True(result != null);
             Assert.True(result?.Count() != 0);
-            Assert.True(result?.Count() == 3);
+            Assert.True(result?.Count() == 6);
         }
 
         [Test]
         public void GetByIdTest()
         {
-            var result = service.GetById(new TypeCatalog { Id = 1});
+            var result = service.GetById(new Catalog { Id = 5});
             Assert.True(result != null);
-            Assert.True(result?.Name == "Tipo de sangre");
+            Assert.True(result?.Name == "Celular");
         }
 
         [Test]
         public void GetByNameTest()
         {
-            var result = service.GetByName(new TypeCatalog { Name = "Tipo" });
+            var result = service.GetByName(new Catalog { Name = "A" });
             Assert.True(result != null);
             Assert.True(result?.Count() != 0);
-            Assert.True(result?.Count() == 2);
+            Assert.True(result?.Count() == 3);
         }
 
         [Test]
         public void SaveTest()
         {
-            var result = service.SaveNew(new TypeCatalog { Id = 4, Name = "Tipo de usuario", Description = "Tipos de usuario que se pueden registrar" });
+            var result = service.SaveNew(new Catalog { Id = 7, Name = "Padre", TypeCatalogId = 3 });
             Assert.True(result != null);
             Assert.True(result?.Count() != 0);
-            Assert.True(result?.Count() == 4);
+            Assert.True(result?.Count() == 7);
         }
 
         [Test]
         public void UpdateTest()
         {
-            TypeCatalog toUpdate = new TypeCatalog { Id = 1, Name = "Tipo de teléfono", Description = "Tipos de teléfono que se pueden registrar" };
-            TypeCatalog original = service.GetById(toUpdate);
+            Catalog toUpdate = new Catalog { Id = 6, Name = "Casa", TypeCatalogId = 3 };
+            Catalog original = service.GetById(toUpdate);
 
             var result = service.Update(toUpdate);
 
             Assert.True(result != null);
             Assert.True(result?.Count() != 0);
-            Assert.True(result?.Count() == 3);
+            Assert.True(result?.Count() == 6);
             Assert.True(result?.First(r => r.Id == toUpdate.Id).Name.ToUpper() == toUpdate.Name.ToUpper());
         }
     }


### PR DESCRIPTION
…for catalog items, including controller, unit tests and perform refactorization process. Data still recides inside the services.

A base class service that contains GetAll, GetById, SaveNew and Delete operations was created, this class now is base class for the services. This new one uses generics to perform this operations. In this way, I don't need to re-code this operations each time I need to add a new service, I only need to implement the new different operations.

The same with the interfaces, one was created for the base class services and the other interfaces inherit from this new one. Now I only need to define those operations that are different.